### PR TITLE
Add redirection for /mp2i (Moved page)

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,2 @@
+# Redirect requests from /mp2i (page moved) to /filiere (Permanent redirection).
+/mp2i /filiere 301


### PR DESCRIPTION
Using IPFS redirections (see https://specs.ipfs.tech/http-gateways/web-redirects-file/), redirect the moved page `/mp2i` to `/filiere`.

See the change in action: https://bafybeid2yiqqsn5c4gojwll4kdrftk5ku3tqkr6ycmqd4zsrr5jh26vggq.ipfs.dweb.link/mp2i/