### PR TITLE
Ajout pour l'entête des personnes concernés

### DIFF
--- a/content/pages/concours.md
+++ b/content/pages/concours.md
@@ -7,6 +7,8 @@ menu:
     main:
         name: Concours
         weight: 4
+tags:
+    - préparationnaires
 categories:
     - Concours
 ---

--- a/content/pages/faq.md
+++ b/content/pages/faq.md
@@ -7,7 +7,7 @@ menu:
         name: FAQ
         weight: 6
 tags:
-    - lycéenss
+    - lycéens
 categories :
     - Orientation
 ---

--- a/content/pages/faq.md
+++ b/content/pages/faq.md
@@ -6,6 +6,8 @@ menu:
     main:
         name: FAQ
         weight: 6
+tags:
+    - lycéenss
 categories :
     - Orientation
 ---

--- a/content/pages/filiere.md
+++ b/content/pages/filiere.md
@@ -3,6 +3,8 @@ title: Les classes préparatoires MP2I et MPI
 subtitle: Vue par les étudiants en MP2I et MPI
 url: /filiere
 date: 2021-12-20T00:07:18+01:00
+tags:
+    - lycéens
 categories:
     - MP2I/MPI
 menu:

--- a/content/pages/informatique.md
+++ b/content/pages/informatique.md
@@ -3,6 +3,8 @@ title: Les cours d'informatique en MP2I et MPI
 subtitle: Une brève introduction à cette matière magique !
 url: /informatique
 date: 2021-12-20T00:07:18+01:00
+tags:
+    - lycéens
 categories:
     - MP2I/MPI
 menu:

--- a/content/pages/rejoindre.md
+++ b/content/pages/rejoindre.md
@@ -3,6 +3,8 @@ title: Comment poursuivre en MP2I après le lycée
 subtitle: Choix des spécialités au lycée et Parcoursup
 url: /rejoindre
 date: 2021-12-20T00:05:32+01:00
+tags:
+    - lycéens
 categories:
     - Orientation
 menu:

--- a/content/posts/forum2022.md
+++ b/content/posts/forum2022.md
@@ -4,6 +4,8 @@ slug: forum-2022
 date: 2022-02-14T16:45:31+01:00
 author: Adridri
 summary: C'était au total plus de 17 établissements présents et plus de 300 visiteurs pour ce premier forum virtuel des MP2I ! Rendez-vous l'année prochaine, les premiers retours d'étudiants en MPI (deuxième année) seront là.
+tags:
+    - lycéens
 categories:
     - Évènements
 ---

--- a/content/posts/forum2023.md
+++ b/content/posts/forum2023.md
@@ -4,6 +4,8 @@ slug: forum-2023
 date: 2023-01-21T13:30:00+01:00
 author: Adridri
 summary: Le forum 2023 est terminé ! Comme l'année dernière, ce ne sont pas moins de 300 élèves ou parents d'élèves qui y ont assisté. En attendant l'édition 2024, vous pouvez télécharger le diaporama utilisé comme support en PDF.
+tags:
+    - lycéens
 categories:
     - Évènements
 ---

--- a/content/posts/forum2024.md
+++ b/content/posts/forum2024.md
@@ -8,6 +8,8 @@ menu:
     main:
         name: Forum
         weight: 5
+tags:
+    - lycéens
 categories:
     - Évènements
 ---

--- a/content/posts/mp2i_ou_mpsi.md
+++ b/content/posts/mp2i_ou_mpsi.md
@@ -5,6 +5,8 @@ slug: mp2i-ou-mpsi
 date: 2023-07-27T00:13:00+01:00
 author: Nozaé
 summary: "Vous êtes au lycée, vous aimez les sciences, vous souhaitez poursuivre en classe préparatoire, mais une question subsiste : MP2I ou MPSI ? Comment choisir la filière qui vous conviendra le mieux ? On vous informe de toutes les différences entre ces deux filières dans ce post."
+tags:
+    - lycéens
 categories:
     - Orientation
 ---

--- a/content/posts/projets.md
+++ b/content/posts/projets.md
@@ -3,6 +3,9 @@ title: Projets personnels d'étudiants
 slug: projets-personnels
 date: 2021-12-20T00:08:50+01:00
 summary: Voici une liste non exhaustive de projets d'étudiants en MP2I ou MPI, n'hésitez pas à les soutenir ! D'autres projets se rajouteront au fur et à mesure ; n'hésitez pas à nous contacter pour y faire figurer le vôtre.
+tags:
+    - lycéens
+    - préparationnaires
 categories:
     - Ressources
 ---

--- a/content/posts/ressources.md
+++ b/content/posts/ressources.md
@@ -4,6 +4,9 @@ subtitle: S'intéresser, apprendre et s'exercer
 slug: ressources
 date: 2021-12-20T00:09:11+01:00
 summary: Des livres traditionnels aux concours nationaux, en passant par les chaînes YouTube pédagogiques, vous trouverez ici de quoi vous divertir scientifiquement pendant vos vacances ou votre temps libre ‒ si vous en avez encore...
+tags:
+    - lycéens
+    - préparationnaires
 categories:
     - Ressources
 ---

--- a/content/posts/scei.md
+++ b/content/posts/scei.md
@@ -2,6 +2,8 @@
 title: Avis des intégrés sur leur école d'ingénieur
 url: /scei
 date: 2024-03-12
+tags:
+    - préparationnaires
 categories:
     - Orientation
 ---

--- a/content/posts/sujets.md
+++ b/content/posts/sujets.md
@@ -4,6 +4,8 @@ subtitle: Entraînez-vous sur les sujets passés
 date: 2023-04-29T23:18:58+02:00
 author: Adridri, Nozaé, Triw
 summary: Venez vous entraîner sur les sujets des années précédentes ! Vous retrouverez également l'accès à une banque d'exercices oraux. Bon courage ;)
+tags:
+    - préparationnaires
 categories:
     - Concours
 ---

--- a/content/posts/tipe.md
+++ b/content/posts/tipe.md
@@ -5,6 +5,9 @@ slug: tipe
 date: 2023-07-18T00:15:00+01:00
 author: Nozaé
 summary: Qu'est-ce que le Travail d'Initiative Personnelle Encadré ? Comment préparer cette épreuve commune à de nombreux concours ? On vous éclaire la lanterne dans ce post dédié ! N'hésitez pas à consulter les exemples en bas de page.
+tags:
+    - lycéens
+    - préparationnaires
 categories:
     - Concours
 ---

--- a/layouts/pages/single.html
+++ b/layouts/pages/single.html
@@ -34,7 +34,7 @@
             {{- end -}}
             <i class="far fa-clock fa-fw"></i>&nbsp;{{ T "readingTime" .ReadingTime }}&nbsp;
             {{- with .Params.tags -}}
-            <i class="fa-solid fa-users"></i>&nbsp;Pour les {{ delimit . " et les " }}&nbsp;
+            <i class="fa fa-user"></i>&nbsp;Pour les {{ delimit . " et les " }}&nbsp;
             {{- end -}}
         </div>
 

--- a/layouts/pages/single.html
+++ b/layouts/pages/single.html
@@ -33,6 +33,9 @@
                 <i class="far fa-calendar-alt fa-fw"></i>&nbsp;Publié le <time datetime="{{ . }}">{{ . }}</time>&nbsp;
             {{- end -}}
             <i class="far fa-clock fa-fw"></i>&nbsp;{{ T "readingTime" .ReadingTime }}&nbsp;
+            {{- with .Params.tags -}}
+            <i class="fa-solid fa-users"></i>&nbsp;Pour les <span class="post-category">{{ delimit . " et les " }}</span>
+            {{- end -}}
         </div>
 
         {{- /* Static TOC */ -}}

--- a/layouts/pages/single.html
+++ b/layouts/pages/single.html
@@ -34,7 +34,7 @@
             {{- end -}}
             <i class="far fa-clock fa-fw"></i>&nbsp;{{ T "readingTime" .ReadingTime }}&nbsp;
             {{- with .Params.tags -}}
-            <i class="fa-solid fa-users"></i>&nbsp;Pour les <span class="post-category">{{ delimit . " et les " }}</span>
+            <i class="fa-solid fa-users"></i>&nbsp;Pour les {{ delimit . " et les " }}&nbsp;
             {{- end -}}
         </div>
 

--- a/layouts/partials/single/footer.html
+++ b/layouts/partials/single/footer.html
@@ -1,0 +1,77 @@
+{{- $params := .Scratch.Get "params" -}}
+
+<div class="post-footer" id="post-footer">
+    <div class="post-info">
+        <div class="post-info-line">
+            <div class="post-info-mod">
+                <span>
+                    {{- with .Site.Params.dateformat | default "2006-01-02" | .Lastmod.Format -}}
+                    {{- dict "Date" . | T "updatedOnDate" -}}
+                    {{- if $.Site.Params.gitRepo -}}
+                    {{- with $.GitInfo -}}
+                    &nbsp;<a class="git-hash" href="{{ printf `%v/commit/%v` $.Site.Params.gitRepo .Hash }}"
+                        target="_blank"
+                        title="commit by {{ .AuthorName }}({{ .AuthorEmail }}) {{ .Hash }}: {{ .Subject }}">
+                        <i class="fas fa-hashtag fa-fw"></i>{{- .AbbreviatedHash -}}
+                    </a>
+                    {{- end -}}
+                    {{- end -}}
+                    {{- end -}}
+                </span>
+            </div>
+            <div class="post-info-license">
+                {{- with $params.license | string -}}
+                <span>
+                    {{- . | safeHTML -}}
+                </span>
+                {{- end -}}
+            </div>
+        </div>
+        <div class="post-info-line">
+            <div class="post-info-md">
+                {{- if $params.linktomarkdown -}}
+                {{- with .OutputFormats.Get "markdown" -}}
+                <span>
+                    <a class="link-to-markdown" href="{{ .RelPermalink }}" target="_blank">
+                        {{- T "readMarkdown" -}}
+                    </a>
+                </span>
+                {{- end -}}
+                {{- end -}}
+            </div>
+            <div class="post-info-share">
+                <span>
+                    {{- partial "plugin/share.html" . -}}
+                </span>
+            </div>
+        </div>
+    </div>
+
+    <div class="post-info-more">
+        <section class="post-tags">
+            <!--{{- with .Params.tags -}}
+                <i class="fas fa-tags fa-fw"></i>&nbsp;
+                {{- range $index, $value := . -}}
+                    {{- if gt $index 0 }},&nbsp;{{ end -}}
+                    {{- $tag := partialCached "function/path.html" $value $value | printf "/tags/%v" | $.Site.GetPage -}}
+                    <a href="{{ $tag.RelPermalink }}">{{ $tag.Title }}</a>
+                {{- end -}}
+            {{- end -}}-->
+        </section>
+        <section>
+            <span><a href="javascript:void(0);" onclick="window.history.back();">{{ T "back"
+                    }}</a></span>&nbsp;|&nbsp;<span><a href="{{ .Site.Home.RelPermalink }}">{{ T "home" }}</a></span>
+        </section>
+    </div>
+
+    <div class="post-nav">
+        {{- if .PrevInSection -}}
+        <a href="{{ .PrevInSection.RelPermalink }}" class="prev" rel="prev" title="{{ .PrevInSection.Title }}"><i
+                class="fas fa-angle-left fa-fw"></i>{{ .PrevInSection.Title }}</a>
+        {{- end -}}
+        {{ if .NextInSection }}
+        <a href="{{ .NextInSection.RelPermalink }}" class="next" rel="next" title="{{ .NextInSection.Title }}">{{
+            .NextInSection.Title }}<i class="fas fa-angle-right fa-fw"></i></a>
+        {{- end -}}
+    </div>
+</div>

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -1,0 +1,111 @@
+{{- define "title" }}{{ .Title }} - {{ .Site.Title }}{{ end -}}
+
+{{- define "content" -}}
+{{- $params := .Scratch.Get "params" -}}
+
+{{- $toc := $params.toc -}}
+{{- if eq $toc true -}}
+{{- $toc = .Site.Params.page.toc | default dict -}}
+{{- else if eq $toc false -}}
+{{- $toc = dict "enable" false -}}
+{{- end -}}
+
+{{- /* Auto TOC */ -}}
+{{- if ne $toc.enable false -}}
+<div class="toc" id="toc-auto">
+    <h2 class="toc-title">{{ T "contents" }}</h2>
+    <div class="toc-content{{ if eq $toc.auto false }} always-active{{ end }}" id="toc-content-auto"></div>
+</div>
+{{- end -}}
+
+<article class="page single">
+    {{- /* Title */ -}}
+    <h1 class="single-title animate__animated animate__flipInX">{{ .Title | emojify }}</h1>
+
+    {{- /* Subtitle */ -}}
+    {{- with $params.subtitle -}}
+    <h2 class="single-subtitle">{{ . }}</h2>
+    {{- end -}}
+
+    {{- /* Meta */ -}}
+    <div class="post-meta">
+        <div class="post-meta-line">
+            {{- $author := $params.author | default .Site.Author.name | default (T "author") -}}
+            {{- $authorLink := $params.authorlink | default .Site.Author.link | default .Site.Home.RelPermalink -}}
+            <span class="post-author">
+                {{- $options := dict "Class" "author" "Destination" $authorLink "Title" "Author" "Rel" "author" "Icon"
+                (dict "Class" "fas fa-user-circle fa-fw") "Content" $author -}}
+                {{- partial "plugin/a.html" $options -}}
+            </span>
+
+            {{- $categories := slice -}}
+            {{- range .Params.categories -}}
+            {{- $category := partialCached "function/path.html" . . | printf "/categories/%v" | $.Site.GetPage -}}
+            {{- $categories = $categories | append (printf `<a href="%v"><i class="far fa-folder fa-fw"
+                    aria-hidden="true"></i>%v</a>` $category.RelPermalink $category.Title) -}}
+            {{- end -}}
+            {{- with delimit $categories "&nbsp;" -}}
+            &nbsp;<span>
+                {{- dict "Categories" . | T "includedInCategories" | safeHTML -}}
+            </span>
+            {{- end -}}
+
+        </div>
+        <div class="post-meta-line">
+            {{- with .Site.Params.dateformat | default "2006-01-02" | .PublishDate.Format -}}
+            <i class="far fa-calendar-alt fa-fw" aria-hidden="true"></i>&nbsp;<time datetime="{{ . }}">{{ .
+                }}</time>&nbsp;
+            {{- end -}}
+            <i class="fas fa-pencil-alt fa-fw" aria-hidden="true"></i>&nbsp;{{ T "wordCount" .WordCount }}&nbsp;
+            <i class="far fa-clock fa-fw" aria-hidden="true"></i>&nbsp;{{ T "readingTime" .ReadingTime }}&nbsp;
+            {{- $comment := .Scratch.Get "comment" | default dict -}}
+            {{- if $comment.enable | and $comment.valine.enable | and $comment.valine.visitor -}}
+            <span id="{{ .RelPermalink }}" class="leancloud_visitors" data-flag-title="{{ .Title }}">
+                <i class="far fa-eye fa-fw" aria-hidden="true"></i>&nbsp;<span
+                    class=leancloud-visitors-count></span>&nbsp;{{ T "views" }}
+            </span>&nbsp;
+            {{- end -}}
+            {{- with .Params.tags -}}
+            <i class="fa-solid fa-users"></i>&nbsp;Pour les <span class="post-category">{{ delimit . " et les "}}</span>
+            {{- end -}}
+        </div>
+    </div>
+
+    {{- /* Featured image */ -}}
+    {{- $image := $params.featuredimage -}}
+    {{- with .Resources.GetMatch "featured-image" -}}
+    {{- $image = .RelPermalink -}}
+    {{- end -}}
+    {{- with $image -}}
+    <div class="featured-image">
+        {{- dict "Src" . "Title" $.Description "Resources" $.Resources | partial "plugin/img.html" -}}
+    </div>
+    {{- end -}}
+
+    {{- /* Static TOC */ -}}
+    {{- if ne $toc.enable false -}}
+    <div class="details toc" id="toc-static" data-kept="{{ if $toc.keepStatic }}true{{ end }}">
+        <div class="details-summary toc-title">
+            <span>{{ T "contents" }}</span>
+            <span><i class="details-icon fas fa-angle-right" aria-hidden="true"></i></span>
+        </div>
+        <div class="details-content toc-content" id="toc-content-static">
+            {{- dict "Content" .TableOfContents "Ruby" $params.ruby "Fraction" $params.fraction "Fontawesome"
+            $params.fontawesome | partial "function/content.html" | safeHTML -}}
+        </div>
+    </div>
+    {{- end -}}
+
+    {{- /* Content */ -}}
+    <div class="content" id="content">
+        {{- dict "Content" .Content "Ruby" $params.ruby "Fraction" $params.fraction "Fontawesome" $params.fontawesome |
+        partial "function/content.html" | safeHTML -}}
+    </div>
+
+    {{- /* Footer */ -}}
+    {{- partial "single/footer.html" . -}}
+
+    {{- /* Comment */ -}}
+    {{- partial "comment.html" . -}}
+</article>
+{{- end -}}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -35,7 +35,7 @@
             <span class="post-author">
                 {{- $options := dict "Class" "author" "Destination" $authorLink "Title" "Author" "Rel" "author" "Icon"
                 (dict "Class" "fas fa-user-circle fa-fw") "Content" $author -}}
-                {{- partial "plugin/a.html" $options -}}
+                {{- partial "plugin/link.html" $options -}}
             </span>
 
             {{- $categories := slice -}}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -66,7 +66,7 @@
             </span>&nbsp;
             {{- end -}}
             {{- with .Params.tags -}}
-            <i class="fa-solid fa-users"></i>&nbsp;Pour les <span class="post-category">{{ delimit . " et les "}}</span>
+            <i class="fa-solid fa-users"></i>&nbsp;Pour les {{ delimit . " et les "}}&nbsp;
             {{- end -}}
         </div>
     </div>

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -66,7 +66,7 @@
             </span>&nbsp;
             {{- end -}}
             {{- with .Params.tags -}}
-            <i class="fa-solid fa-users"></i>&nbsp;Pour les {{ delimit . " et les "}}&nbsp;
+            <i class="fa fa-user"></i></i>&nbsp;Pour les {{ delimit . " et les "}}&nbsp;
             {{- end -}}
         </div>
     </div>


### PR DESCRIPTION
J'ai remarqué que le site mélange un peu les pages/posts à destination des lycéens et des préparationnaires.
J'ai modifié un peu le site pour ajouter à l'entête cette information.

![image](https://github.com/prepas-mp2i/prepas-mp2i.fr/assets/61625831/d8b08e52-a6b0-41de-8f43-5385bfff268e)
